### PR TITLE
Use `None` for blank username

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,9 +144,17 @@ pub struct Uri {
 }
 
 macro_rules! map_to_string {
-    ( $x:expr ) => {
-        $x.map(String::from);
-    };
+    ( $x:expr ) => ({
+        if let Some(contents) = $x.map(String::from) {
+            if contents == "" {
+                None
+            } else {
+                Some(contents)
+            }
+        } else {
+            None
+        }
+    });
 }
 
 macro_rules! map_to_u16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,16 @@ mod test {
     }
 
     #[test]
+    fn blank_username_should_parse_as_none() {
+        let uri_with_blank_username = "http://some.host/";
+        if let Some(parsed_uri) = ::Uri::new(uri_with_blank_username) {
+            assert_eq!(parsed_uri.username, None);
+        } else {
+            panic!("Cannot create a URI from a valid string");
+        }
+    }
+
+    #[test]
     fn uri_new() {
         match ::Uri::new(URI_GOOD_STRING) {
             Some(uri) => {


### PR DESCRIPTION
Instead of parsing a missing username as `Some("")`, it should be parsed as `None`. This behavior is consistent with how the password is handled, and makes client logic a bit cleaner, e.g.

```rust
if let Some(username) = some_uri.username {
    if username != "" {
        // use username
    }
}

// versus

if let Some(username) = some_uri.username {
    // use username
}
```

Note that this technically applies to all of the `Uri` struct members.

I think this might be a breaking change for clients relying on empty components.