### PR TITLE
Use lazy_static to create regexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "uri is a library to help in the creation and parsing of an uri."
 [dependencies]
 regex = "0.1"
 clippy = {version = "0.0.37", optional = true}
+lazy_static = "0.2"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@
 /// extern crate uri;
 /// ```
 
+#[macro_use]
+extern crate lazy_static;
 extern crate regex;
 use regex::*;
 
@@ -155,6 +157,10 @@ macro_rules! map_to_u16 {
     };
 }
 
+lazy_static! {
+    static ref URI_REGEX: Regex = Regex::new(URI_PATTERN).unwrap();
+}
+
 static URI_PATTERN: &'static str = "^(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*):\
                                     /{0,3}\
                                     (?P<username>.*?)?\
@@ -164,7 +170,6 @@ static URI_PATTERN: &'static str = "^(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*):\
                                     (:?(?P<path>/[^?#]*))?\
                                     (?:\\?(?P<query>[^#]*))?\
                                     (?:#(?P<fragment>.*))?$";
-
 
 /// Checks if a given string is an URI.
 ///
@@ -177,11 +182,7 @@ static URI_PATTERN: &'static str = "^(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*):\
 /// assert_eq!(result, true);
 /// ```
 pub fn is_uri(uristr: &str) -> bool {
-    let uri_re = Regex::new("([a-zA-Z][a-zA-Z0-9+.-]*):\
-                            ([^?#]*)\
-                            (?:\\?([^#]*))?\
-                            (?:#(.*))?").unwrap();
-    uri_re.is_match(uristr)
+    URI_REGEX.is_match(uristr)
 }
 
 impl Uri {
@@ -217,8 +218,7 @@ impl Uri {
             fragment: None,
         };
 
-        let uri_re = Regex::new(URI_PATTERN).unwrap();
-        match uri_re.captures(uristr) {
+        match URI_REGEX.captures(uristr) {
             Some(caps) => {
                 match caps.name("scheme") {
                     Some(scheme) => uri.scheme = String::from(scheme),


### PR DESCRIPTION
This follows the [example](https://doc.rust-lang.org/regex/regex/index.html#example-avoid-compiling-the-same-regex-in-a-loop) given in the documentation for the `regex` crate to avoid creating multiple instances of the same regex for each invocation of `Uri::new` and `is_uri`.